### PR TITLE
Add classes to be able to support Additional Properties for messages

### DIFF
--- a/src/Properties/AdditionalPropertiesResolver.php
+++ b/src/Properties/AdditionalPropertiesResolver.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SimpleBus\Asynchronous\Properties;
+
+use SimpleBus\Message\Message;
+
+interface AdditionalPropertiesResolver
+{
+    /**
+     * Determine additional properties for messages containing a serialized version of this Message
+     *
+     * @param Message $message
+     * @return array The array of additional properties or empty array
+     */
+    public function resolveAdditionalPropertiesFor(Message $message);
+}

--- a/src/Properties/DelegatingAdditionalPropertiesResolver.php
+++ b/src/Properties/DelegatingAdditionalPropertiesResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SimpleBus\Asynchronous\Properties;
+
+use SimpleBus\Message\Message;
+
+class DelegatingAdditionalPropertiesResolver implements AdditionalPropertiesResolver
+{
+    /**
+     * @var AdditionalPropertiesResolver[]
+     */
+    private $resolvers;
+
+    public function __construct($resolvers)
+    {
+        $this->resolvers = $resolvers;
+    }
+
+    /**
+     * Combine properties
+     *
+     * @{inheritdoc}
+     */
+    public function resolveAdditionalPropertiesFor(Message $message)
+    {
+        $properties = [];
+
+        foreach ($this->resolvers as $resolver) {
+            $properties = array_merge($properties, $resolver->resolveAdditionalPropertiesFor($message));
+        }
+
+        return $properties;
+    }
+}

--- a/tests/Properties/DelegatingAdditionalPropertiesResolverTest.php
+++ b/tests/Properties/DelegatingAdditionalPropertiesResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SimpleBus\Asynchronous\Tests\Properties;
+
+use SimpleBus\Asynchronous\Properties\AdditionalPropertiesResolver;
+use SimpleBus\Asynchronous\Properties\DelegatingAdditionalPropertiesResolver;
+use SimpleBus\Message\Message;
+
+class DelegatingAdditionalPropertiesResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_merge_multiple_resolvers()
+    {
+        $message = $this->messageDummy();
+
+        $resolver = new DelegatingAdditionalPropertiesResolver(array(
+            $this->getResolver($message, array('test' => 'a')),
+            $this->getResolver($message, array('test' => 'b', 'priority' => 123)),
+        ));
+
+        $this->assertSame(['test' => 'b', 'priority' => 123], $resolver->resolveAdditionalPropertiesFor($message));
+    }
+
+    /**
+     * @param Message $message
+     * @param array   $data
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|AdditionalPropertiesResolver
+     */
+    private function getResolver(Message $message, array $data)
+    {
+        $resolver = $this->getMock('SimpleBus\Asynchronous\Properties\AdditionalPropertiesResolver');
+        $resolver->expects($this->once())
+            ->method('resolveAdditionalPropertiesFor')
+            ->with($this->identicalTo($message))
+            ->will($this->returnValue($data));
+
+        return $resolver;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Message
+     */
+    private function messageDummy()
+    {
+        return $this->getMock('SimpleBus\Message\Message');
+    }
+}


### PR DESCRIPTION
RabbitMQ 3.5 has a method to send a message with different priority's. But currently we can't send additional properties to the consumer. I implemented the base classes here but did not give an implementation like the routing key resolver. Because this really depends. Personally i'm using an `AsyncPriority` interface which has one method `getPriority` and than i can send the same message with different priorities.

Our use case is that we have a CommandHandler which is generating video's from images. We have a cronjob that gets new images from different api's and from that it generates images. But sometimes a customer needs de latest video fast and with the priority option it can skip the line and proces faster. 

The implementation for this can be found here https://github.com/SimpleBus/RabbitMQBundleBridge/pull/9 this is without the `AsyncPriority` interface.
