### PR TITLE
Added a middleware to only publish predefined messages

### DIFF
--- a/doc/publishing_messages.md
+++ b/doc/publishing_messages.md
@@ -5,9 +5,12 @@ currentMenu: publishing_messages
 # Publishing messages
 
 When a `Message` should not be handled by the message bus (i.e. command or event bus) immediately (i.e. synchronously),
-it can be *published* to be handled by some other process. This library comes with two strategies for publishing
-messages: either a message will always *also* be published, or it will only be published when the message bus isn't able
-to handle it because there is no handler defined for it.
+it can be *published* to be handled by some other process. This library comes with three strategies for publishing
+messages:
+
+1. A message will always *also* be published.
+2. A message will only be published when the message bus isn't able to handle it because there is no handler defined for it.
+3. A message will be published only if its name exists in a predefined list.
 
 ## Strategy 1: Always publish messages
 
@@ -77,5 +80,36 @@ always publish a command. Instead, it should only be published when it *couldn't
 Possibly some other process knows how to handle it.
 
 If no command handler was found and the command is published, this will be logged using the provided `$logger`.
+
+## Strategy 3: Only publish predefined messages
+
+This strategy is useful when you know what messages you want to publish. 
+
+```php
+use SimpleBus\Message\Bus\Middleware\MessageBusSupportingMiddleware;
+use SimpleBus\Asynchronous\MessageBus\AlwaysPublishesMessages;
+use SimpleBus\Asynchronous\Publisher\Publisher;
+use SimpleBus\Message\Message;
+use SimpleBus\Message\Name\MessageNameResolver;
+
+// $eventBus is an instance of MessageBusSupportingMiddleware
+$eventBus = ...;
+
+// $publisher is an instance of Publisher
+$publisher = ...;
+
+// $messageNameResolver is an instance of MessageNameResolver
+$messageNameResolver = ...;
+
+// The list of names will depend on what MessageNameResolver you are using. 
+$names = ['My\\Event', 'My\\Other\\Event'];
+
+$eventBus->appendMiddleware(new PublishesPredefinedMessages($publisher, $messageNameResolver, $names));
+
+// $event is an object
+$event = ...;
+
+$eventBus->handle($event);
+```
 
 *Continue reading about [consuming messages](consuming_messages.md)*

--- a/src/MessageBus/PublishesPredefinedMessages.php
+++ b/src/MessageBus/PublishesPredefinedMessages.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SimpleBus\Asynchronous\MessageBus;
+
+use SimpleBus\Asynchronous\Publisher\Publisher;
+use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
+use SimpleBus\Message\Name\MessageNameResolver;
+
+class PublishesPredefinedMessages implements MessageBusMiddleware
+{
+    /**
+     * @var \SimpleBus\Asynchronous\Publisher\Publisher
+     */
+    private $publisher;
+
+    /**
+     * @var MessageNameResolver
+     */
+    private $messageNameResolver;
+
+    /**
+     * @var array names
+     */
+    private $names;
+
+    /**
+     * @param Publisher $publisher
+     * @param MessageNameResolver $messageNameResolver
+     * @param array $names an array with names on messages to be published.
+     */
+    public function __construct(Publisher $publisher, MessageNameResolver $messageNameResolver, array $names)
+    {
+        $this->publisher = $publisher;
+        $this->messageNameResolver = $messageNameResolver;
+        $this->names = $names;
+    }
+
+    /**
+     * Handle a message by publishing it to a queue (always), then calling the next middleware
+     *
+     * {@inheritdoc}
+     */
+    public function handle($message, callable $next)
+    {
+        $name = $this->messageNameResolver->resolve($message);
+        if (in_array($name, $this->names)) {
+            $this->publisher->publish($message);
+        }
+
+        $next($message);
+    }
+}

--- a/tests/MessageBus/PublishesPredefinedMessagesTest.php
+++ b/tests/MessageBus/PublishesPredefinedMessagesTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace SimpleBus\Asynchronous\Tests\MessageBus;
+
+use SimpleBus\Asynchronous\MessageBus\PublishesPredefinedMessages;
+use SimpleBus\Asynchronous\Publisher\Publisher;
+use SimpleBus\Message\CallableResolver\Exception\UndefinedCallable;
+use SimpleBus\Message\Name\MessageNameResolver;
+
+class PublishesPredefinedMessagesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_calls_the_next_middleware_and_when_the_message_is_handled_it_does_not_publish_it()
+    {
+        $message = $this->dummyMessage();
+
+        $nextCallableCalled = false;
+        $alwaysSucceedingNextCallable = function ($actualMessage) use ($message, &$nextCallableCalled) {
+            $nextCallableCalled = true;
+            $this->assertSame($message, $actualMessage);
+        };
+
+        $publisher = $this->mockPublisher();
+        $publisher
+            ->expects($this->never())
+            ->method('publish');
+
+        $nameResolver = $this->mockNameResolver();
+        $nameResolver->method('resolve')
+            ->willReturn('foo');
+
+        $middleware = new PublishesPredefinedMessages($publisher, $nameResolver, ['baz', 'bar']);
+
+        $middleware->handle($message, $alwaysSucceedingNextCallable);
+
+        $this->assertTrue($nextCallableCalled);
+    }
+
+    /**
+     * @test
+     */
+    public function it_calls_the_next_middleware_and_when_the_message_has_no_handler_it_publishes_it()
+    {
+        $message = $this->dummyMessage();
+
+        $nextCallableCalled = false;
+        $alwaysSucceedingNextCallable = function ($actualMessage) use ($message, &$nextCallableCalled) {
+            $nextCallableCalled = true;
+            $this->assertSame($message, $actualMessage);
+        };
+
+        $publisher = $this->mockPublisher();
+        $publisher
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->identicalTo($message));
+
+        $nameResolver = $this->mockNameResolver();
+        $nameResolver->method('resolve')
+            ->willReturn('foo');
+
+        $middleware = new PublishesPredefinedMessages($publisher, $nameResolver, ['baz', 'foo', 'bar']);
+
+        $middleware->handle($message, $alwaysSucceedingNextCallable);
+
+        $this->assertTrue($nextCallableCalled);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Publisher
+     */
+    private function mockPublisher()
+    {
+        return $this->getMock('SimpleBus\Asynchronous\Publisher\Publisher');
+    }
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|MessageNameResolver
+     */
+    private function mockNameResolver()
+    {
+        return $this->getMock('SimpleBus\Message\Name\MessageNameResolver');
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|object
+     */
+    private function dummyMessage()
+    {
+        return new \stdClass();
+    }
+}


### PR DESCRIPTION
We currently have two strategies to publish messages on a queue; _unhandled_ and _all_. This adds a middleware where you can define names of messages that will be published.

This PR makes much more sense with the other PR at the Asynchronous Bundle, lets discuss the possibility to merge this feature there: https://github.com/SimpleBus/AsynchronousBundle/pull/6
### TODO
- [x] Add tests
- [x] Add docs
