### PR TITLE
Update ClassBasedRoutingKeyResolver.php

### DIFF
--- a/src/Routing/ClassBasedRoutingKeyResolver.php
+++ b/src/Routing/ClassBasedRoutingKeyResolver.php
@@ -4,11 +4,11 @@ namespace SimpleBus\Asynchronous\Routing;
 
 class ClassBasedRoutingKeyResolver implements RoutingKeyResolver
 {
-    public function resolveRoutingKeyFor($message)
+    public function resolveRoutingKeyFor($message, $separator = '.')
     {
         return str_replace(
             '\\',
-            '.',
+            $separator,
             get_class($message)
         );
     }

--- a/src/Routing/ClassBasedRoutingKeyResolver.php
+++ b/src/Routing/ClassBasedRoutingKeyResolver.php
@@ -20,7 +20,7 @@ class ClassBasedRoutingKeyResolver implements RoutingKeyResolver
 
     /**
      * @param object | string $message
-     * 
+     *
      * @return string
      */
     public function resolveRoutingKeyFor($message)

--- a/src/Routing/ClassBasedRoutingKeyResolver.php
+++ b/src/Routing/ClassBasedRoutingKeyResolver.php
@@ -4,12 +4,48 @@ namespace SimpleBus\Asynchronous\Routing;
 
 class ClassBasedRoutingKeyResolver implements RoutingKeyResolver
 {
-    public function resolveRoutingKeyFor($message, $separator = '.')
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * @var string
+     */
+    private $separator;
+
+    /**
+     * @var string
+     */
+    private $suffix;
+
+    /**
+     * @param string $separator
+     * @param string $prefix
+     * @param string $suffix
+     */
+    public function __construct($separator = '.', $prefix = null, $suffix = null)
     {
-        return str_replace(
-            '\\',
-            $separator,
-            get_class($message)
-        );
+        $this->separator = $separator;
+        if ($prefix !== null) {
+            $this->prefix = $prefix;
+        }
+        if ($suffix !== null) {
+            $this->suffix = $suffix;
+        }
+    }
+
+    public function resolveRoutingKeyFor($message)
+    {
+        $components = explode('\\', is_object($message) ? get_class($message) : $message);
+
+        if(isset($this->prefix)){
+            array_unshift($components, $this->prefix);
+        }
+        if(isset($this->suffix)){
+            $components[] = $this->suffix;
+        }
+
+        return implode($this->separator, $components);
     }
 }

--- a/src/Routing/ClassBasedRoutingKeyResolver.php
+++ b/src/Routing/ClassBasedRoutingKeyResolver.php
@@ -4,10 +4,6 @@ namespace SimpleBus\Asynchronous\Routing;
 
 class ClassBasedRoutingKeyResolver implements RoutingKeyResolver
 {
-    /**
-     * @var string
-     */
-    private $prefix;
 
     /**
      * @var string
@@ -15,37 +11,24 @@ class ClassBasedRoutingKeyResolver implements RoutingKeyResolver
     private $separator;
 
     /**
-     * @var string
-     */
-    private $suffix;
-
-    /**
      * @param string $separator
-     * @param string $prefix
-     * @param string $suffix
      */
-    public function __construct($separator = '.', $prefix = null, $suffix = null)
+    public function __construct($separator = '.')
     {
         $this->separator = $separator;
-        if ($prefix !== null) {
-            $this->prefix = $prefix;
-        }
-        if ($suffix !== null) {
-            $this->suffix = $suffix;
-        }
     }
 
+    /**
+     * @param object | string $message
+     * 
+     * @return string
+     */
     public function resolveRoutingKeyFor($message)
     {
-        $components = explode('\\', is_object($message) ? get_class($message) : $message);
-
-        if(isset($this->prefix)){
-            array_unshift($components, $this->prefix);
-        }
-        if(isset($this->suffix)){
-            $components[] = $this->suffix;
-        }
-
-        return implode($this->separator, $components);
+        return str_replace(
+            '\\',
+            $this->separator,
+            is_object($message) ? get_class($message) : $message
+        );
     }
 }

--- a/src/Routing/PrefixBasedResolver.php
+++ b/src/Routing/PrefixBasedResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SimpleBus\Asynchronous\Routing;
+
+class PrefixBasedResolver implements RoutingKeyResolver
+{
+    /**
+     * @var RoutingKeyResolver
+     */
+    private $parent;
+
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * @var string
+     */
+    private $suffix;
+
+    /**
+     * @param RoutingKeyResolver $parent
+     * @param string $prefix
+     * @param string $suffix
+     */
+    public function __construct(RoutingKeyResolver $parent, $prefix = null, $suffix = null)
+    {
+        $this->parent = $parent;
+        if (is_string($prefix)) {
+            $this->prefix = $prefix;
+        }
+        if (is_string($suffix)) {
+            $this->suffix = $suffix;
+        }
+    }
+
+    public function resolveRoutingKeyFor($message)
+    {
+        $message = '';
+
+        if (isset($this->prefix)) {
+            $message .= $this->prefix;
+        }
+
+        $message .= $this->parent->resolveRoutingKeyFor($message);
+
+        if (isset($this->suffix)) {
+            $message .= $this->prefix;
+        }
+
+        return $message;
+    }
+}

--- a/src/Routing/PrefixBasedResolver.php
+++ b/src/Routing/PrefixBasedResolver.php
@@ -37,18 +37,18 @@ class PrefixBasedResolver implements RoutingKeyResolver
 
     public function resolveRoutingKeyFor($message)
     {
-        $message = '';
+        $routingKey = '';
 
         if (isset($this->prefix)) {
-            $message .= $this->prefix;
+            $routingKey .= $this->prefix;
         }
 
-        $message .= $this->parent->resolveRoutingKeyFor($message);
+        $routingKey .= $this->parent->resolveRoutingKeyFor($message);
 
         if (isset($this->suffix)) {
-            $message .= $this->prefix;
+            $routingKey .= $this->suffix;
         }
 
-        return $message;
+        return $routingKey;
     }
 }

--- a/src/Routing/RoutingKeyResolver.php
+++ b/src/Routing/RoutingKeyResolver.php
@@ -7,7 +7,7 @@ interface RoutingKeyResolver
     /**
      * Determine a routing key for messages containing a serialized version of this message
      *
-     * @param object $message
+     * @param object | string $message
      * @return string The routing key or empty string if no routing key needs to be used
      */
     public function resolveRoutingKeyFor($message);

--- a/tests/Routing/ClassBasedRoutingKeyResolverTest.php
+++ b/tests/Routing/ClassBasedRoutingKeyResolverTest.php
@@ -19,4 +19,16 @@ class ClassBasedRoutingKeyResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('SimpleBus.Asynchronous.Tests.Routing.Fixtures.MessageDummy', $routingKey);
     }
+
+    /**
+     * @test
+     */
+    public function it_resolves_string_values()
+    {
+        $resolver = new ClassBasedRoutingKeyResolver();
+
+        $routingKey = $resolver->resolveRoutingKeyFor(MessageDummy::class);
+
+        $this->assertSame('SimpleBus.Asynchronous.Tests.Routing.Fixtures.MessageDummy', $routingKey);
+    }
 }

--- a/tests/Routing/PrefixBasedResolverTest.php
+++ b/tests/Routing/PrefixBasedResolverTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SimpleBus\Asynchronous\Tests\Routing;
+
+use SimpleBus\Asynchronous\Routing\ClassBasedRoutingKeyResolver;
+use SimpleBus\Asynchronous\Routing\PrefixBasedResolver;
+use SimpleBus\Asynchronous\Tests\Routing\Fixtures\MessageDummy;
+
+class PrefixBasedResolverTest extends \PHPUnit_Framework_TestCase
+{
+    private $prefix = 'DummyPrefix';
+
+    private $suffix = 'DummySuffix';
+
+    /**
+     * @test
+     */
+    public function it_returns_the_fqcn()
+    {
+        $message = new MessageDummy();
+        $parentResolver = new ClassBasedRoutingKeyResolver();
+        $resolver = new PrefixBasedResolver($parentResolver);
+
+        $routingKey = $resolver->resolveRoutingKeyFor($message);
+
+        $this->assertSame('SimpleBus.Asynchronous.Tests.Routing.Fixtures.MessageDummy', $routingKey);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_fqcn_with_prefix()
+    {
+        $message = new MessageDummy();
+        $parentResolver = new ClassBasedRoutingKeyResolver();
+        $resolver = new PrefixBasedResolver($parentResolver, $this->prefix);
+
+        $routingKey = $resolver->resolveRoutingKeyFor($message);
+
+        $this->assertSame($this->prefix . 'SimpleBus.Asynchronous.Tests.Routing.Fixtures.MessageDummy', $routingKey);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_fqcn_with_prefix_and_suffix()
+    {
+        $message = new MessageDummy();
+        $parentResolver = new ClassBasedRoutingKeyResolver();
+        $resolver = new PrefixBasedResolver($parentResolver, $this->prefix, $this->suffix);
+
+        $routingKey = $resolver->resolveRoutingKeyFor($message);
+
+        $this->assertSame($this->prefix . 'SimpleBus.Asynchronous.Tests.Routing.Fixtures.MessageDummy' . $this->suffix, $routingKey);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_fqcn_with_suffix()
+    {
+        $message = new MessageDummy();
+        $parentResolver = new ClassBasedRoutingKeyResolver();
+        $resolver = new PrefixBasedResolver($parentResolver, null, $this->suffix);
+
+        $routingKey = $resolver->resolveRoutingKeyFor($message);
+
+        $this->assertSame('SimpleBus.Asynchronous.Tests.Routing.Fixtures.MessageDummy' . $this->suffix, $routingKey);
+    }
+
+}


### PR DESCRIPTION
Allow other separator characters. Amazon SQS does not allow the (default) dots in queue names...